### PR TITLE
fix: env var typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ functions:
     timeout: 30
     environment:
       SLS_TYPEORM_MIGRATIONS_ENGINE: "postgres"
-      SLS_TYPEORM_MIGRATION_DATABASE_URL: "postgres://root:password@domain.rds.amazonaws.com:5432/database"
-      SLS_TYPEORM_MIGRATION_OLDER: "src/migration/**/*.js"
+      SLS_TYPEORM_MIGRATIONS_DATABASE_URL: "postgres://root:password@domain.rds.amazonaws.com:5432/database"
+      SLS_TYPEORM_MIGRATION_FOLDER: "src/migration/**/*.js"
   down:
     handler: migrations.down
     timeout: 30
     environment:
       SLS_TYPEORM_MIGRATIONS_ENGINE: "postgres"
-      SLS_TYPEORM_MIGRATION_DATABASE_URL: "postgres://root:password@domain.rds.amazonaws.com:5432/database"
-      SLS_TYPEORM_MIGRATION_OLDER: "src/migration/**/*.js"
+      SLS_TYPEORM_MIGRATIONS_DATABASE_URL: "postgres://root:password@domain.rds.amazonaws.com:5432/database"
+      SLS_TYPEORM_MIGRATION_FOLDER: "src/migration/**/*.js"
 ```
 
 Pass the function to the serverless deploy command to have it execute after the deploy is finished:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export function getDatabaseConnectionString(logger: (message: string) => void) {
 
 export function getEngine(logger: (message: string) => void): any {
   if (!process.env.SLS_TYPEORM_MIGRATIONS_ENGINE) {
-    logger("SLS_TYPEORM_MIGRATIONS_DATABASE_URL environment variable required");
+    logger("SLS_TYPEORM_MIGRATIONS_ENGINE environment variable required");
     process.exit(1);
   }
   return process.env.SLS_TYPEORM_MIGRATIONS_ENGINE;


### PR DESCRIPTION
I found a small error message bug.  I hope this will save others from wondering why database url env is not reflected (I forgot to specify engine in my .env, which lead me to find this issue).  There are also some type in README.